### PR TITLE
Improvements to publishing script

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,4 @@
-/publish.sh
+publish.sh
+.travis/
+.travis.yml
+VERSION.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
   - ./publish.sh
 deploy:
   provider: npm
+  emai: govuk-dev@digital.cabinet-office.gov.uk
   api_key:
     secure: lQumjzh4nXch5pVm3KopTlso+PBLAiEhiq1mLmp7Au2L5KnRI06FiLwoBEgDodDMPA6XHdd2Yhrzs8hlufgIYtcJOwfGbv2uTz/kOgXkdpjsUOpQgekZ1wTKNjBdJEmHX9AGhwckfvi5y14bRNQYUyXNpv75MC4xph/pbImKt3w=
   on:

--- a/publish.sh
+++ b/publish.sh
@@ -23,12 +23,21 @@ rm -rf docs
 rm -rf spec
 rm -f CONTRIBUTING.md
 rm -f Gruntfile.js
-rm -f jenkins.sh
 rm -f Gemfile
 rm -f Gemfile.lock
+rm -f push.sh
+rm -f trigger.sh
 
 # Move the actual toolkit files into the repo where this script is
-rsync -a * ..
+# --delete:  delete extraneous files from dest dir
+# --archive: preserves permissions, times, symbolic links, etc
+
+# Note: src of `*` is different from `.`, especially for delete!
+# - `*` expands to each file/dir in src, which are rsync'd individually. A file that exists in dest
+#   but not src won't be deleted. This is the behaviour we want.
+# - `.` copies the directory in one go, deleting ANY files in dest that are not in src, which will
+#   delete key files in this repo - like `package.json`, even `.git/`
+rsync --delete --archive * ..
 
 cd ..
 
@@ -39,7 +48,11 @@ VERSION_LATEST=`cat VERSION.txt`
 VERSION_REGISTRY=`npm view govuk_frontend_toolkit version`
 
 if [ "$VERSION_LATEST" != "$VERSION_REGISTRY" ]; then
-  git commit -am "Temporary commit: new toolkit files"
+  # Adds, modifies, and removes index entries to match the working tree.
+  # https://git-scm.com/docs/git-add#git-add--A
+  git add --all
+
+  git commit -m "Temporary commit: new toolkit files"
   npm version $VERSION_LATEST
   git reset --soft HEAD~2
   git commit -am "Bump npm version of govuk_frontend_toolkit to $VERSION_LATEST"

--- a/publish.sh
+++ b/publish.sh
@@ -48,14 +48,15 @@ VERSION_LATEST=`cat VERSION.txt`
 VERSION_REGISTRY=`npm view govuk_frontend_toolkit version`
 
 if [ "$VERSION_LATEST" != "$VERSION_REGISTRY" ]; then
+  # Update `package.json` version field, without creating it's own commit or tag
+  # https://docs.npmjs.com/cli/version
+  npm version --no-git-tag-version $VERSION_LATEST
+
   # Adds, modifies, and removes index entries to match the working tree.
   # https://git-scm.com/docs/git-add#git-add--A
   git add --all
 
-  git commit -m "Temporary commit: new toolkit files"
-  npm version $VERSION_LATEST
-  git reset --soft HEAD~2
-  git commit -am "Bump npm version of govuk_frontend_toolkit to $VERSION_LATEST"
+  git commit -m "Bump npm version of govuk_frontend_toolkit to $VERSION_LATEST"
   git push origin_ssh master
 else
   echo 'VERSION.txt is the same as the version available on the registry'


### PR DESCRIPTION
**Background**

This repo hasn't been staying in sync with changes from FET. Previous discussion: https://github.com/alphagov/govuk_frontend_toolkit_npm/pull/15

**Problems**

1. *Deletion*: This repo contains files removed from FET. These are also included the code published to `npm`. It _shouldn't_ have broken the package for users, but could cause confusion where files that have deprecated/removed are still in the package.
2. *Addition*: This repo is missing files added to FET, that _are_ included in the code published to `npm`, but are not reflected in the commits here.

**Changes**

- The changes to `npmignore` aren't directly related, but also make the publish process a little more explicit about what we want to publish.

- The second commit does the bulk of the work. Using `rsync --delete` ensures files removed from FET are removed from the local file system. Using `git add --all` ensures deleted files are removed from the git index, it also ensures new files are added. 

- I found the `git commit` / `npm version` / `git reset` / `git commit` dance difficult to follow, so i've tried to simplify it for the next person.

**Output**

This branch shows the output of manually running the new `publish.sh` script: 
https://github.com/alphagov/govuk_frontend_toolkit_npm/compare/simpler-publish-script...simpler-publish-script-output.

That output is reflects all the missed additions/deletions and will bring this repo and FET in sync, so it's pretty big. Subsequent publishings will only reflect the changes between the last and new versions.

**What else needs doing?**

- [ ] Deleting the [v5.1.1 commit](https://github.com/alphagov/govuk_frontend_toolkit_npm/commit/725df6509f7fcd2eebade32262ec8dd09676b8ff) - as it's not been published to `npm`, and the [publishing script will fail](https://travis-ci.org/alphagov/govuk_frontend_toolkit_npm/builds/202590751) if `package.json` matches `VERSION.txt`