### PR TITLE
Force bump the npm package version

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -51,7 +51,7 @@ VERSION_REGISTRY=`npm view govuk_frontend_toolkit version`
 if [ "$VERSION_LATEST" != "$VERSION_REGISTRY" ]; then
   # Update `package.json` version field, without creating it's own commit or tag
   # https://docs.npmjs.com/cli/version
-  npm version --no-git-tag-version $VERSION_LATEST
+  npm version -f --no-git-tag-version $VERSION_LATEST
 
   # Adds, modifies, and removes index entries to match the working tree.
   # https://git-scm.com/docs/git-add#git-add--A


### PR DESCRIPTION
https://docs.npmjs.com/cli/version

`npm version -f --no-git-tag-version $VERSION_LATEST`

Run this in a package directory to bump the version and write the new data back to package.json.

If run in a git repo, it will also create a version commit and tag. Since we don't want a version commit and a tag - this behavior is disabled by running `npm --no-git-tag-version` version. It will fail if the working directory is not clean, unless the -f or --force flag is set.