### PR TITLE
Add skip_cleanup: true for npm deployment step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,6 @@ deploy:
     email: govuk-dev@digital.cabinet-office.gov.uk
     api_key:
       secure: JNPzkjCkl3YF52/OPsu6PNZ4T5hCoBrqVAygpp4+VNs2//18hYkTRFiA0xSLDab8JBOp6lb9Ukqp2mjZh50zPKyc8Vd98cYrG5Wmbi/79lQwfX4AuQ9yAq7tgdMicvjQcyvbDK1uwPpQ56uiCTx4O4hNftWe1CJBrYY0xbzs1KA=
+    skip_cleanup: true
     on:
       branch: master


### PR DESCRIPTION
This is to ensure the files copied by publish.sh aren’t cleaned up by
Travis before deployment to npm begins.

https://travis-ci.org/alphagov/govuk_frontend_toolkit_npm#L231

Merge this before the reverting the 6.0.4 release in #27.