### PR TITLE
Add govuk_frontend_toolkit subfolder to npm ignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ publish.sh
 .travis/
 .travis.yml
 VERSION.txt
+govuk_frontend_toolkit/


### PR DESCRIPTION
The govuk_frontend_toolkit folder is created when copying files the govuk_frontend_toolkit repo.

When running `npm pack` locally, this file appears in the release when it shouldn't. 
Ensure this folder is added to .npmignore.