### PR TITLE
Use new api key for npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,22 @@ language: node_js
 sudo: false
 branches:
   only:
-    - master
+  - master
 before_install:
-  - openssl aes-256-cbc -K $encrypted_6c266e67b443_key -iv $encrypted_6c266e67b443_iv -in .travis/govuk_frontend_toolkit_npm_push.enc -out ~/.ssh/id_rsa -d
-  - chmod 600 ~/.ssh/id_rsa
-  - git config --global user.name "GOV.UK Patterns & Tools CI User"
-  - git config --global user.email "patterns-and-tools-github-user@digital.cabinet-office.gov.uk"
-  - git remote add origin_ssh git@github.com:alphagov/govuk_frontend_toolkit_npm.git
+- openssl aes-256-cbc -K $encrypted_6c266e67b443_key -iv $encrypted_6c266e67b443_iv
+  -in .travis/govuk_frontend_toolkit_npm_push.enc -out ~/.ssh/id_rsa -d
+- chmod 600 ~/.ssh/id_rsa
+- git config --global user.name "GOV.UK Patterns & Tools CI User"
+- git config --global user.email "patterns-and-tools-github-user@digital.cabinet-office.gov.uk"
+- git remote add origin_ssh git@github.com:alphagov/govuk_frontend_toolkit_npm.git
 install:
-  - echo "No dependencies to install"
+- echo "No dependencies to install"
 script:
-  - ./publish.sh
+- "./publish.sh"
 deploy:
   provider: npm
   email: govuk-dev@digital.cabinet-office.gov.uk
   api_key:
-    secure: JNPzkjCkl3YF52/OPsu6PNZ4T5hCoBrqVAygpp4+VNs2//18hYkTRFiA0xSLDab8JBOp6lb9Ukqp2mjZh50zPKyc8Vd98cYrG5Wmbi/79lQwfX4AuQ9yAq7tgdMicvjQcyvbDK1uwPpQ56uiCTx4O4hNftWe1CJBrYY0xbzs1KA=
+    secure: WZnMvGdigSaq2nbM5FDPi0NCuf799YpLx7OCRMKmqzW82WbQExd22C9mhGpDvdR9wgZ4iMxtZtqYYkyRInl684f18xZj6yUbh3fkLTdq661/ZXl+MNNwMFOkiEYrgurBcvCKk8Cn81/9Phi0oWqFIjgvb5+S5/lvNah0tUnIQGE=
   on:
     branch: master


### PR DESCRIPTION
Encrypt and add api key to .travis.yml by running:

`travis encrypt --add deploy.api_key <apikey>.`

Formatting changes have also been made by the travis command line tool
when running the above command.