### PR TITLE
Update README to reflect deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
-The GOV.UK Design System launched on 22 June 2018
-===============
-
-GOV.UK Frontend Toolkit has now been replaced by the GOV.UK Design System. The Toolkit will remain available in case you are currently using it, but is no longer maintained. The Government Digital Service will only carry out major bug fixes and security patches.
-
-The GOV.UK Design System will be updated to ensure the things it contains meet level AA of WCAG 2.1, but GOV.UK Frontend Toolkit will not. [Read more about accessibility of the GOV.UK Design System](https://design-system.service.gov.uk/accessibility/).
-
----
+> [!WARNING]
+> GOV.UK Frontend Toolkit is deprecated. To design your service using actively maintained and accessible styles, components and patterns, [migrate to the GOV.UK Design System](https://frontend.design-system.service.gov.uk/v4/migrating-from-legacy-products/).
 
 # GOV.UK frontend toolkit npm package
 


### PR DESCRIPTION
Removed deprecated information about the GOV.UK Frontend Toolkit and added a warning about migration to the GOV.UK Design System.